### PR TITLE
add build/lint jobs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,33 @@
+name: Build and Test
+on:
+  push:
+    branches:
+      - main
+  pull_request: {}
+jobs:
+  build_and_test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      # report each failing OS/toolchain build - useful for separating between OS failures vs. toolchain (nightly) failures
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - macos-latest
+          - windows-latest
+        toolchain:
+          - stable
+          - nightly
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build with toolchain ${{ matrix.toolchain }}
+        uses: actions-rs/toolchain@v1
+        with:
+          command: build
+          args: --release --all-features
+          toolchain: ${{ matrix.toolchain }}
+      - name: Test with toolchain ${{ matrix.toolchain }}
+        uses: actions-rs/toolchain@v1
+        with:
+          command: test
+          toolchain: ${{ matrix.toolchain }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,3 +31,20 @@ jobs:
         with:
           command: test
           toolchain: ${{ matrix.toolchain }}
+          args: --workspace --lib
+      - name: Test docs with toolchain ${{ matrix.toolchain }}
+        uses: actions-rs/toolchain@v1
+        with:
+          command: test
+          toolchain: ${{ matrix.toolchain }}
+          args: --doc --all
+      - name: Check formatting
+        uses: actions-rs/toolchain@v1
+        with:
+          command: fmt
+          args: --all -- --check
+      - name: Clippy
+        uses: actions-rs/toolchain@v1
+        with:
+          command: clippy
+          args: --workspace

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,20 @@
+name: Lint Documentation
+on:
+  push:
+    paths: 'docs/**'
+    branches:
+      - main
+  pull_request:
+    paths: 'docs/**'
+jobs:
+  lint_docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+      - name: Install markdownlint
+        run: npm install -g markdownlint-cli
+      - name: markdownlint
+        run: markdownlint '**/*.md' -c .markdownlint.json


### PR DESCRIPTION
This introduces a test workflow for krator. Most of the code was pulled from the Krustlet project.

We will still want an "upload to crates.io" release job, but this should help automate unit tests for incoming contributions to the project.

refs #3 