### PR TITLE
chore(*): Bump the krator and derive versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -867,7 +867,7 @@ dependencies = [
 
 [[package]]
 name = "krator"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -899,7 +899,7 @@ dependencies = [
 
 [[package]]
 name = "krator-derive"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "k8s-openapi",

--- a/krator-derive/Cargo.toml
+++ b/krator-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krator-derive"
-version = "0.2.0"
+version = "0.3.0"
 authors = [
     "Kevin Flansburg <kevin.flansburg@gmail.com>",
     "Taylor Thomas <taylor.thomas@microsoft.com>",

--- a/krator/Cargo.toml
+++ b/krator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "krator"
-version = "0.3.0"
+version = "0.4.0"
 authors = [
     "Kevin Flansburg <kevin.flansburg@gmail.com>",
     "Taylor Thomas <taylor.thomas@microsoft.com>",
@@ -41,7 +41,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_yaml = { version = "0.8", optional = true }
 futures = { version = "0.3", default-features = false }
-krator-derive = { version = "0.2", path = "../krator-derive", optional = true }
+krator-derive = { version = "0.3", path = "../krator-derive", optional = true }
 warp = { version = "0.3", optional = true, features = ["tls"] }
 json-patch = { version = "0.2", optional = true }
 tracing = { version = "0.1", features = ['log'] }


### PR DESCRIPTION
This is in preparation for the 0.4 release of Krator. This is needed
because supporting k8s 1.21 required a version bump of the k8s_openapi
crate, which contained breaking changes. Because of those breaking
changes, it is a breaking change as well for krator. This still supports
any version of k8s that k8s_openapi does