### PR TITLE
Fix UI tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Install toolchain stable
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: nightly
           default: true
       - name: UI Test with toolchain stable
         uses: actions-rs/cargo@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,9 +200,8 @@ dependencies = [
 
 [[package]]
 name = "compiletest_rs"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0086d6ad78cf409c3061618cd98e2789d5c9ce598fc9651611cf62eae0a599cb"
+version = "0.7.0"
+source = "git+https://github.com/kflansburg/compiletest-rs.git#1fed0133bef7066447622840f66c257e0502f436"
 dependencies = [
  "diff",
  "filetime",

--- a/krator/Cargo.toml
+++ b/krator/Cargo.toml
@@ -68,7 +68,7 @@ tokio = { version = "1.0", features = ["fs", "macros", "signal", "rt-multi-threa
 opentelemetry-jaeger = "0.11"
 tracing-opentelemetry = "0.11"
 structopt = "0.3"
-compiletest_rs = "0.6"
+compiletest_rs = { version = "0.7", git = "https://github.com/kflansburg/compiletest-rs.git" }
 
 [[example]]
 name = "moose"

--- a/krator/tests/ui.rs
+++ b/krator/tests/ui.rs
@@ -22,6 +22,7 @@ fn compile_test() {
     let mut config = compiletest_rs::Config {
         mode: compiletest_rs::common::Mode::Ui,
         src_base: PathBuf::from("tests/ui"),
+        target_rustcflags: Some(" -Z ui-testing ".to_string()),
         ..Default::default()
     };
     link_deps(&mut config);

--- a/krator/tests/ui/state/cannot_construct_transition_next.stderr
+++ b/krator/tests/ui/state/cannot_construct_transition_next.stderr
@@ -1,7 +1,7 @@
 error[E0451]: field `state` of struct `StateHolder` is private
   --> $DIR/cannot_construct_transition_next.rs:26:9
    |
-26 |         state: Box::new(Stub),
+LL |         state: Box::new(Stub),
    |         ^^^^^^^^^^^^^^^^^^^^^ private field
 
 error: aborting due to previous error

--- a/krator/tests/ui/state/next_must_be_state.stderr
+++ b/krator/tests/ui/state/next_must_be_state.stderr
@@ -1,10 +1,16 @@
 error[E0277]: the trait bound `NotState: krator::State<PodState>` is not satisfied
   --> $DIR/next_must_be_state.rs:39:9
    |
-39 |         Transition::next(self, NotState)
+LL |         Transition::next(self, NotState)
    |         ^^^^^^^^^^^^^^^^ the trait `krator::State<PodState>` is not implemented for `NotState`
    |
-   = note: required by `Transition::<S>::next`
+note: required by `Transition::<S>::next`
+  --> $SRC_DIR/src/state.rs:43:5
+   |
+LL | /     pub fn next<I: State<S>, O: State<S>>(_i: Box<I>, o: O) -> Transition<S>
+LL | |     where
+LL | |         I: TransitionTo<O>,
+   | |___________________________^
 
 error: aborting due to previous error
 

--- a/krator/tests/ui/state/require_same_object_state.stderr
+++ b/krator/tests/ui/state/require_same_object_state.stderr
@@ -1,12 +1,18 @@
 error[E0277]: the trait bound `OtherState: krator::State<PodState>` is not satisfied
   --> $DIR/require_same_object_state.rs:50:9
    |
-50 |         Transition::next(self, OtherState)
+LL |         Transition::next(self, OtherState)
    |         ^^^^^^^^^^^^^^^^ the trait `krator::State<PodState>` is not implemented for `OtherState`
    |
    = help: the following implementations were found:
              <OtherState as krator::State<OtherPodState>>
-   = note: required by `Transition::<S>::next`
+note: required by `Transition::<S>::next`
+  --> $SRC_DIR/src/state.rs:43:5
+   |
+LL | /     pub fn next<I: State<S>, O: State<S>>(_i: Box<I>, o: O) -> Transition<S>
+LL | |     where
+LL | |         I: TransitionTo<O>,
+   | |___________________________^
 
 error: aborting due to previous error
 

--- a/krator/tests/ui/state/require_transition_to.stderr
+++ b/krator/tests/ui/state/require_transition_to.stderr
@@ -1,10 +1,16 @@
 error[E0277]: the trait bound `TestState: TransitionTo<_>` is not satisfied
   --> $DIR/require_transition_to.rs:38:9
    |
-38 |         Transition::next(self, TestState)
+LL |         Transition::next(self, TestState)
    |         ^^^^^^^^^^^^^^^^ the trait `TransitionTo<_>` is not implemented for `TestState`
    |
-   = note: required by `Transition::<S>::next`
+note: required by `Transition::<S>::next`
+  --> $SRC_DIR/src/state.rs:43:5
+   |
+LL | /     pub fn next<I: State<S>, O: State<S>>(_i: Box<I>, o: O) -> Transition<S>
+LL | |     where
+LL | |         I: TransitionTo<O>,
+   | |___________________________^
 
 error: aborting due to previous error
 


### PR DESCRIPTION
The outcome of the issue I opened for `rustc`, is that the normalization functionality that is used for the Rust compiler is only partially implemented in the crate which allows UI tests to be run on other codebases (`compiletest_rs`). I have opened a PR with that project to add the missing normalization behavior. For now, I have configured Cargo to use my forked version of the code with the patch.

https://github.com/rust-lang/rust/issues/88819
https://github.com/Manishearth/compiletest-rs/pull/244