### PR TITLE
Ignore time-related advisories

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -48,7 +48,8 @@ notice = "warn"
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
 ignore = [
-    #"RUSTSEC-0000-0000",
+    "RUSTSEC-2020-0071",
+    "RUSTSEC-2020-0159"
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories


### PR DESCRIPTION
This instructs `cargo deny` to ignore the two advisories related to the `time` crate:

#57 
#58 

See the first issue for my investigation and explanation for why I believe these do not impact Krator. 