### PR TITLE
Install stable toolchain for audit workflow

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -9,6 +9,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
+      - name: Install toolchain stable 
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          default: true
       - uses: actions-rs/audit-check@v1.2.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/krator/tests/ui/state/require_transition_to.stderr
+++ b/krator/tests/ui/state/require_transition_to.stderr
@@ -1,10 +1,8 @@
 error[E0277]: the trait bound `TestState: TransitionTo<_>` is not satisfied
-  --> $DIR/require_transition_to.rs:38:32
+  --> $DIR/require_transition_to.rs:38:9
    |
 LL |         Transition::next(self, TestState)
-   |         ----------------       ^^^^^^^^^ the trait `TransitionTo<_>` is not implemented for `TestState`
-   |         |
-   |         required by a bound introduced by this call
+   |         ^^^^^^^^^^^^^^^^ the trait `TransitionTo<_>` is not implemented for `TestState`
    |
 note: required by `Transition::<S>::next`
   --> $SRC_DIR/src/state.rs:43:5


### PR DESCRIPTION
Our audit workflow has been failing since we bumped to edition 2021 since it was running with `1.55`. This PR brings it to parity with our other workflows (always install latest `stable`). 